### PR TITLE
feature/data-rest

### DIFF
--- a/data-rest/pom.xml
+++ b/data-rest/pom.xml
@@ -20,6 +20,7 @@
   <properties>
     <java.version>1.8</java.version>
     <informix.version>4.50.4.1</informix.version>
+    <owasp.version>6.1.5</owasp.version>
   </properties>
 
   <dependencies>
@@ -77,19 +78,25 @@
         </exclusion>
       </exclusions>
     </dependency>
-  </dependencies>
 
-  <dependency>
-    <groupId>org.springframework.security</groupId>
-    <artifactId>spring-security-test</artifactId>
-    <scope>test</scope>
-  </dependency>
+    <dependency>
+      <groupId>org.springframework.security</groupId>
+      <artifactId>spring-security-test</artifactId>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
 
   <build>
     <plugins>
       <plugin>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-maven-plugin</artifactId>
+      </plugin>
+
+      <plugin>
+        <groupId>org.owasp</groupId>
+        <artifactId>dependency-check-maven</artifactId>
+        <version>${owasp.version}</version>
       </plugin>
     </plugins>
   </build>

--- a/data-rest/src/main/java/gr/nothingness/backofficeusermanager/configuration/ApplicationConfiguration.java
+++ b/data-rest/src/main/java/gr/nothingness/backofficeusermanager/configuration/ApplicationConfiguration.java
@@ -9,6 +9,7 @@ import org.springframework.context.annotation.Configuration;
 @ConfigurationProperties(prefix = "app")
 public class ApplicationConfiguration {
 
+  @Getter @Setter private String basePath = "/";
   @Getter @Setter private boolean authDisabled = false;
   @Getter @Setter private boolean csrfDisabled = true;
   @Getter @Setter private String readPermission = "ReadAccess";

--- a/data-rest/src/main/java/gr/nothingness/backofficeusermanager/configuration/ApplicationConfiguration.java
+++ b/data-rest/src/main/java/gr/nothingness/backofficeusermanager/configuration/ApplicationConfiguration.java
@@ -11,7 +11,6 @@ public class ApplicationConfiguration {
 
   @Getter @Setter private boolean authDisabled = false;
   @Getter @Setter private boolean csrfDisabled = true;
-  @Getter @Setter private boolean sessionStateless = false;
   @Getter @Setter private String readPermission = "ReadAccess";
   @Getter @Setter private String writePermission = "WriteAccess";
   @Getter @Setter private String httpStatusRefUrl = "https://httpstatuses.com";

--- a/data-rest/src/main/java/gr/nothingness/backofficeusermanager/security/configuration/SecurityConfiguration.java
+++ b/data-rest/src/main/java/gr/nothingness/backofficeusermanager/security/configuration/SecurityConfiguration.java
@@ -31,7 +31,6 @@ public class SecurityConfiguration extends WebSecurityConfigurerAdapter {
 
   @Override
   protected void configure(HttpSecurity httpSecurity) throws Exception {
-
     if (configuration.isAuthDisabled()) {
       httpSecurity
           .anonymous();
@@ -42,6 +41,9 @@ public class SecurityConfiguration extends WebSecurityConfigurerAdapter {
           .authorizeRequests()
           .mvcMatchers(HttpMethod.GET, "/**").hasAuthority(configuration.getReadPermission())
           .anyRequest().hasAuthority(configuration.getWritePermission())
+          .and()
+          .sessionManagement()
+          .sessionCreationPolicy(STATELESS)
           .and()
           .exceptionHandling()
           .authenticationEntryPoint((request, response, exception) -> {
@@ -66,12 +68,6 @@ public class SecurityConfiguration extends WebSecurityConfigurerAdapter {
       httpSecurity
           .csrf()
           .disable();
-    }
-
-    if (configuration.isSessionStateless()) {
-      httpSecurity
-          .sessionManagement()
-          .sessionCreationPolicy(STATELESS);
     }
   }
 

--- a/data-rest/src/main/java/gr/nothingness/backofficeusermanager/security/configuration/SecurityConfiguration.java
+++ b/data-rest/src/main/java/gr/nothingness/backofficeusermanager/security/configuration/SecurityConfiguration.java
@@ -1,5 +1,6 @@
 package gr.nothingness.backofficeusermanager.security.configuration;
 
+import static org.springframework.http.HttpMethod.GET;
 import static org.springframework.http.HttpStatus.UNAUTHORIZED;
 import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 import static org.springframework.security.config.http.SessionCreationPolicy.STATELESS;
@@ -39,27 +40,29 @@ public class SecurityConfiguration extends WebSecurityConfigurerAdapter {
           .httpBasic()
           .and()
           .authorizeRequests()
-          .mvcMatchers(HttpMethod.GET, "/**").hasAuthority(configuration.getReadPermission())
-          .anyRequest().hasAuthority(configuration.getWritePermission())
+              .mvcMatchers(GET, "/actuator/health").permitAll()
+              .mvcMatchers(GET, configuration.getBasePath()).permitAll()
+              .mvcMatchers(GET, "/**").hasAuthority(configuration.getReadPermission())
+              .anyRequest().hasAuthority(configuration.getWritePermission())
           .and()
           .sessionManagement()
-          .sessionCreationPolicy(STATELESS)
+              .sessionCreationPolicy(STATELESS)
           .and()
           .exceptionHandling()
-          .authenticationEntryPoint((request, response, exception) -> {
-                RFC7807Error apiError = RFC7807Error
-                    .withStatus(UNAUTHORIZED)
-                    .andType(configuration.getHttpStatusRefUrl() + "/" + UNAUTHORIZED.value())
-                    .andTitle("Unauthorized")
-                    .andDetail(exception.getMessage())
-                    .andInstance(request.getRequestURI())
-                    .build();
+              .authenticationEntryPoint((request, response, exception) -> {
+                    RFC7807Error apiError = RFC7807Error
+                        .withStatus(UNAUTHORIZED)
+                        .andType(configuration.getHttpStatusRefUrl() + "/" + UNAUTHORIZED.value())
+                        .andTitle("Unauthorized")
+                        .andDetail(exception.getMessage())
+                        .andInstance(request.getRequestURI())
+                        .build();
 
-                response.setContentType(APPLICATION_JSON_VALUE);
-                response.setStatus(UNAUTHORIZED.value());
+                    response.setContentType(APPLICATION_JSON_VALUE);
+                    response.setStatus(UNAUTHORIZED.value());
 
-                ObjectMapper mapper = new ObjectMapper();
-                mapper.writeValue(response.getOutputStream(), apiError.toMap());
+                    ObjectMapper mapper = new ObjectMapper();
+                    mapper.writeValue(response.getOutputStream(), apiError.toMap());
               }
           );
     }

--- a/data-rest/src/main/resources/application.properties
+++ b/data-rest/src/main/resources/application.properties
@@ -2,7 +2,7 @@ server.port                                                 = 50002
 
 spring.output.ansi.enabled                                  = always
 
-spring.data.rest.basePath                                   = /api/v1
+spring.data.rest.basePath                                   = ${app.base-path}
 
 spring.datasource.url                                       = jdbc:informix-sqli://localhost:9088/openbet:INFORMIXSERVER=informix;IFX_TRIMTRAILINGSPACES=1
 spring.datasource.username                                  = informix
@@ -20,6 +20,7 @@ logging.level.org.hibernate.SQL                             = DEBUG
 logging.level.org.hibernate.stat                            = WARN
 logging.level.org.hibernate.type.descriptor.sql.BasicBinder = TRACE
 
+app.base-path                                               = /api/v1
 app.auth-disabled                                           = false
 app.csrf-disabled                                           = true
 app.read-permission                                         = UseAdmin

--- a/data-rest/src/main/resources/application.properties
+++ b/data-rest/src/main/resources/application.properties
@@ -22,7 +22,6 @@ logging.level.org.hibernate.type.descriptor.sql.BasicBinder = TRACE
 
 app.auth-disabled                                           = false
 app.csrf-disabled                                           = true
-app.session-stateless                                       = false
 app.read-permission                                         = UseAdmin
 app.write-permission                                        = AssignRights
 app.http-status-ref-url                                     = https://httpstatuses.com/

--- a/qa/postman/build_acceptance_tests.json
+++ b/qa/postman/build_acceptance_tests.json
@@ -45,6 +45,9 @@
 						}
 					],
 					"request": {
+						"auth": {
+							"type": "noauth"
+						},
 						"method": "GET",
 						"header": [],
 						"url": {
@@ -96,6 +99,9 @@
 						}
 					],
 					"request": {
+						"auth": {
+							"type": "noauth"
+						},
 						"method": "GET",
 						"header": [],
 						"url": {


### PR DESCRIPTION
- Forcing stateless session management, as REST is stateless
- Adding the OWASP dependency check maven plugin
- Allowing unauthenticated access to the health actuator and to the root endpoint